### PR TITLE
use hints for creating Graph Definition instead of labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,18 @@ var (
 	// These keys are mapped to Mackerel's attributes.
 	keyHostID      = key.New("host.id")               // custom identifier
 	keyHostName    = key.New("host.name")             // hostname
-	keyGraphClass  = key.New("mackerel.graph.class")  // graph-def's name
-	keyMetricClass = key.New("mackerel.metric.class") // graph-def's metric name
+
+	hints = []string{
+		"storage.#",
+	}
 )
 
 func main() {
 	apiKey := os.Getenv("MACKEREL_APIKEY")
-	pusher, _ := mackerel.InstallNewPipeline(mackerel.WithAPIKey(apiKey))
+	pusher, _ := mackerel.InstallNewPipeline(
+		mackerel.WithAPIKey(apiKey),
+		mackerel.WithHints(hints),
+	)
 	defer pusher.Stop()
 
 	meter := global.MeterProvider().Meter("example")
@@ -46,8 +51,6 @@ func main() {
 	labels := meter.Labels(
 		keyHostID.String("10-1-2-241"),
 		keyHostName.String("localhost"),
-		keyGraphClass.String("storage.#"),
-		keyMetricClass.String("storage.#.*"),
 	)
 	ctx := context.Background()
 	firestoreRead.Add(ctx, 100, labels)

--- a/graphdef.go
+++ b/graphdef.go
@@ -33,67 +33,51 @@ func JoinMetricName(elem ...string) string {
 	return strings.Join(a, metricNameSep)
 }
 
+func metricNamePrefix(s string) string {
+	a := strings.Split(s, metricNameSep)
+	if len(a) == 0 {
+		return ""
+	}
+	return strings.Join(a[:len(a)-1], metricNameSep)
+}
+
 // GraphDefOptions represents options for customizing Mackerel's Graph Definition.
 type GraphDefOptions struct {
-	Name       string
-	MetricName string
-	Unit       unit.Unit
-	Kind       core.NumberKind
-	Quantiles  []float64
+	Name      string
+	Unit      unit.Unit
+	Kind      core.NumberKind
+	Quantiles []float64
 }
+
+var errMismatch = errors.New("mismatched metric names")
 
 // NewGraphDef returns Mackerel's Graph Definition. Each names in arguments must be canonicalized.
 func NewGraphDef(name string, kind export.MetricKind, opts GraphDefOptions) (*mackerel.GraphDefsParam, error) {
 	if opts.Unit == "" {
 		opts.Unit = UnitDimensionless
 	}
-	switch {
-	case opts.MetricName == "" && opts.Name == "":
-		opts.MetricName = generalizeMetricName(name)
-		opts.Name = opts.MetricName
-	case opts.MetricName == "" && opts.Name != "":
-		s, err := replaceMetricNamePrefix(name, opts.Name)
-		if err != nil {
-			return nil, err
-		}
-		opts.MetricName = s
-	case opts.MetricName != "" && opts.Name == "":
-		opts.Name = opts.MetricName
+	if kind == export.MeasureKind {
+		name = JoinMetricName(name, "max") // Anything is fine
 	}
-	if !MetricName(opts.MetricName).Match(name) {
+	if opts.Name == "" {
+		opts.Name = metricNamePrefix(name)
+	}
+	r := JoinMetricName(opts.Name, "*")
+	if !MetricName(r).Match(name) {
 		return nil, errMismatch
 	}
-	g := &mackerel.GraphDefsParam{
+	return &mackerel.GraphDefsParam{
 		Name: opts.Name,
 		Unit: graphUnit(opts.Unit, opts.Kind),
-	}
-	if kind == export.MeasureKind {
-		g.Metrics = measureMetrics(opts.MetricName, opts.Quantiles)
-	} else {
-		g.Metrics = []*mackerel.GraphDefsMetric{
-			{Name: opts.MetricName},
-		}
-	}
-	return g, nil
+		Metrics: []*mackerel.GraphDefsMetric{
+			{Name: r},
+		},
+	}, nil
 }
 
 // PercentileName returns "percentile_xx".
 func PercentileName(q float64) string {
 	return fmt.Sprintf("percentile_%.0f", math.Floor(q*100))
-}
-
-func measureMetrics(name string, quantiles []float64) []*mackerel.GraphDefsMetric {
-	suffixes := []string{"min", "max"}
-	for _, q := range quantiles {
-		suffixes = append(suffixes, PercentileName(q))
-	}
-	var a []*mackerel.GraphDefsMetric
-	for _, s := range suffixes {
-		a = append(a, &mackerel.GraphDefsMetric{
-			Name: JoinMetricName(name, s),
-		})
-	}
-	return a
 }
 
 func graphUnit(u unit.Unit, kind core.NumberKind) string {
@@ -111,41 +95,6 @@ func graphUnit(u unit.Unit, kind core.NumberKind) string {
 		}
 		return "float"
 	}
-}
-
-var errMismatch = errors.New("mismatched metric names")
-
-// replaceMetricNamePrefix returns prefix + rest of s.
-func replaceMetricNamePrefix(s, prefix string) (string, error) {
-	a1 := strings.Split(prefix, metricNameSep)
-	a2 := strings.Split(s, metricNameSep)
-	if len(a1) > len(a2) {
-		return "", errMismatch
-	}
-	t := strings.Join(a2[:len(a1)], metricNameSep)
-	if !MetricName(prefix).Match(t) {
-		return "", errMismatch
-	}
-	copy(a2[:len(a1)], a1)
-	return strings.Join(a2, metricNameSep), nil
-}
-
-// generalizeMetricName generalize "a.b" to "a.*" if s don't contain wildcards.
-func generalizeMetricName(s string) string {
-	if s == "" {
-		return ""
-	}
-	a := strings.Split(s, metricNameSep)
-	for _, stem := range a {
-		if stem == "*" {
-			return s
-		}
-	}
-	if a[len(a)-1] == "#" {
-		return s
-	}
-	a[len(a)-1] = "*"
-	return strings.Join(a, metricNameSep)
 }
 
 // CanonicalMetricName returns canonical metric name.

--- a/host.go
+++ b/host.go
@@ -24,18 +24,13 @@ var (
 	keyHostID            = core.Key("host.id")
 	keyHostName          = core.Key("host.name")
 	keyCloudProvider     = core.Key("cloud.provider")
-
-	// for graph-def
-	keyGraphClass  = core.Key("mackerel.graph.class")
-	keyMetricClass = core.Key("mackerel.metric.class")
 )
 
 // Resource represents a resource constructed with labels.
 type Resource struct {
-	Service  ServiceResource  `resource:"service"`
-	Host     HostResource     `resource:"host"`
-	Cloud    CloudResource    `resource:"cloud"`
-	Mackerel MackerelResource `resource:"mackerel"`
+	Service ServiceResource `resource:"service"`
+	Host    HostResource    `resource:"host"`
+	Cloud   CloudResource   `resource:"cloud"`
 }
 
 // ServiceResource represents the standard service attributes.
@@ -60,16 +55,6 @@ type HostResource struct {
 // CloudResource represents the standard cloud attributes.
 type CloudResource struct {
 	Provider string `resource:"provider"`
-}
-
-// MackerelResource represents Mackerel specific resources.
-type MackerelResource struct {
-	Metric struct {
-		Class string `resource:"class"`
-	} `resource:"metric"`
-	Graph struct {
-		Class string `resource:"class"`
-	} `resource:"graph"`
 }
 
 // Hostname returns a proper hostname.


### PR DESCRIPTION
When the application records metrics with RecordBatch, there is no way that to use different label set per each metric.

Thus I decided to use pre-defined hints instead of label set for declaring Graph Definition.

1. Metric name in graph definition is generated from metric name if there is no hints matched to metric name.
2. If metric names is matched to a hint, these metric names are collects into a single graph definition.